### PR TITLE
Tentative v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.8 - Feb 27 2023 
+- Comments fix in `nginx.conf`
+- Upgraded to `<replay-web-page>` 1.7.13
+
 ## v0.0.7 - Feb 07 2023 
 - Allow `?url` to remain unspecified to match `<replay-web-page>`'s behavior.
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,7 +54,7 @@ server {
   location ~ \.warc {
     types { } default_type "application/warc";
     try_files /archives/$uri /archives/$uri/ @remote_warc_archive;
-    # EDIT: Delete "@remote_warc_machine" from the above list if you do not wish to proxy a remote server.
+    # EDIT: Delete "@remote_warc_archive" from the above list if you do not wish to proxy a remote server.
   }
 
   location ~ \.warc.gz {
@@ -67,7 +67,7 @@ server {
   location ~ \.wacz {
     types { } default_type "application/wacz";
     try_files /archives/$uri /archives/$uri/ @remote_wacz_archive;
-    # EDIT: Delete "@remote_wacz_machine" from the above list if you do not wish to proxy a remote server.
+    # EDIT: Delete "@remote_wacz_archive" from the above list if you do not wish to proxy a remote server.
   }
 
   # EDIT: Delete this block if you do not wish to proxy a remote server.

--- a/pull-replay-web-page.sh
+++ b/pull-replay-web-page.sh
@@ -1,3 +1,3 @@
 # Pulls the latest version of `<replay-web-page>` (https://replayweb.page)
-curl https://cdn.jsdelivr.net/npm/replaywebpage@1.7.12/sw.js > html/replay-web-page/sw.js
-curl https://cdn.jsdelivr.net/npm/replaywebpage@1.7.12/ui.js > html/replay-web-page/ui.js
+curl https://cdn.jsdelivr.net/npm/replaywebpage@1.7.13/sw.js > html/replay-web-page/sw.js
+curl https://cdn.jsdelivr.net/npm/replaywebpage@1.7.13/ui.js > html/replay-web-page/ui.js


### PR DESCRIPTION
- Upgrade to replayweb.page 1.7.13 (https://github.com/webrecorder/replayweb.page/releases/tag/v1.7.13)
- `nginx.conf` comments fix